### PR TITLE
Update GitHub and Travis CI URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,7 @@ Changes
 - Installation issues in environments with LC_ALL=C are fixed;
 - PyPy is officially unsupported now (use DAWG-Python_ with PyPy).
 
-.. _DAWG-Python: https://github.com/kmike/DAWG-Python
+.. _DAWG-Python: https://github.com/pytries/DAWG-Python
 
 0.6 (2013-03-22)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 DAWG
 ====
 
-.. image:: https://travis-ci.org/kmike/DAWG.png?branch=master
-    :target: https://travis-ci.org/kmike/DAWG
+.. image:: https://travis-ci.org/pytries/DAWG.png?branch=master
+    :target: https://travis-ci.org/pytries/DAWG
 
 This package provides DAWG(DAFSA_)-based dictionary-like
 read-only objects for Python (2.x and 3.x).
@@ -14,8 +14,8 @@ it also provides fast advanced methods like prefix search.
 .. _DAFSA: https://en.wikipedia.org/wiki/Deterministic_acyclic_finite_state_automaton
 
 * Docs: http://dawg.readthedocs.org
-* Source code: https://github.com/kmike/DAWG
-* Issue tracker: https://github.com/kmike/DAWG/issues
+* Source code: https://github.com/pytries/DAWG
+* Issue tracker: https://github.com/pytries/DAWG/issues
 
 License
 =======

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -324,7 +324,7 @@ with different data structures (under Python 2.7):
     based on this README file. It is still several times slower than
     DAWG though.
 
-.. _marisa-trie: https://github.com/kmike/marisa-trie
+.. _marisa-trie: https://github.com/pytries/marisa-trie
 
 Benchmark results (100k unicode words, integer values (lengths of the words),
 Python 3.3, macbook air i5 1.8 Ghz)::
@@ -416,9 +416,9 @@ Contributions are welcome!
 Contributing
 ============
 
-Development happens at github: https://github.com/kmike/DAWG
+Development happens at github: https://github.com/pytries/DAWG
 
-Issue tracker: https://github.com/kmike/DAWG/issues
+Issue tracker: https://github.com/pytries/DAWG/issues
 
 Feel free to submit ideas, bugs or pull requests.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     long_description = open('README.rst').read() +'\n\n' + open('CHANGES.rst').read(),
     author='Mikhail Korobov',
     author_email='kmike84@gmail.com',
-    url='https://github.com/kmike/DAWG/',
+    url='https://github.com/pytries/DAWG/',
 
     ext_modules = [
         Extension(


### PR DESCRIPTION
DAWG and marisa-trie have been moved to the pytries organization.