### PR TITLE
Fix cython build error and expose three more methods

### DIFF
--- a/src/dawg.pyx
+++ b/src/dawg.pyx
@@ -176,6 +176,17 @@ cdef class DAWG:
 
     def _file_size(self):
         return self.dct.file_size()
+    
+    cpdef BaseType root(self):
+        return self.dct.root()
+
+    cpdef (bint, BaseType) follow(self, unicode label, BaseType index):
+        cdef bytes _label = <bytes>label.encode('utf8')
+        rs = self.dct.Follow(_label, &index)
+        return rs, index
+
+    def has_value(self, index: BaseType) -> bool:
+        return self._has_value(index) 
 
     cdef bint _has_value(self, BaseType index):
         return  self.dct.has_value(index)

--- a/src/dawg.pyx
+++ b/src/dawg.pyx
@@ -86,7 +86,7 @@ cdef class DAWG:
     cpdef bint b_has_key(self, bytes key) except -1:
         return self.dct.Contains(key, len(key))
 
-    cpdef bytes tobytes(self):
+    cpdef bytes tobytes(self) except +:
         """
         Return raw DAWG content as bytes.
         """


### PR DESCRIPTION
I would like to add a fix for this issue: https://github.com/pytries/DAWG/issues/31
Also I would like to expose 3 more methods, they are **has_value()**, **root()** and **follow()**. They will be useful if we want to scan a string then highlight every matched keywords, for example:

**Target string:** "One two three!"
**List of keywords:** ["one", "three"]
```python
import dawg
import re

targetedStr = 'one two three!'
targetLen = len(targetedStr)
dic = dawg.DAWG(['one', 'three'])
index = dic.root()
hasMore = False
reportedStr = ""
bufferedStr = ""
isContainingKeywords = False
for i, chr in enumerate(targetedStr):
    willRedoInNextLoop = True
    while (willRedoInNextLoop):
        willRedoInNextLoop = False
        bufferedStr += targetedStr[i]
        hasMore, index = dic.follow(chr, index)
        isEgdeCase = (hasMore == True and i + 1 >= targetLen)
        if (hasMore == False or isEgdeCase == True):
            if (dic.has_value(index)):
                # Keyword detected!
                keyword = bufferedStr if isEgdeCase else bufferedStr[0:(
                    len(bufferedStr) - 1)]
                reportedStr += "{" + keyword + "}"
                isContainingKeywords = True
                if not isEgdeCase:
                    willRedoInNextLoop = True
            else:
                # Not a keyword
                reportedStr += bufferedStr
            bufferedStr = ""
            index = dic.root()
if (isContainingKeywords == True):
    reportedStr += bufferedStr 
    print(reportedStr)
```
Output:
```bash
{one} two {three}!
```