### PR TITLE
README.rst: link to readthedocs.org via https

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ it also provides fast advanced methods like prefix search.
 
 .. _DAFSA: https://en.wikipedia.org/wiki/Deterministic_acyclic_finite_state_automaton
 
-* Docs: http://dawg.readthedocs.org
+* Docs: https://dawg.readthedocs.org
 * Source code: https://github.com/pytries/DAWG
 * Issue tracker: https://github.com/pytries/DAWG/issues
 


### PR DESCRIPTION
This is a super trivial fix to the documentation.

`http://dawg.readthedocs.org` -> `https://dawg.readthedocs.org`